### PR TITLE
Lower maximum content length

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -8,7 +8,7 @@ const client = new Discord.Client();
 const cblockre = /(^```js)|(```$)/g;
 
 async function respond(message, content) {
-  if (content.length > 1985) {
+  if (content.length > 1960) {
     const key = await request.post('https://hastebin.com/documents')
       .send(content)
       .then((r) => r.body.key);


### PR DESCRIPTION
Message.replying with a code block alone is ~35 characters. So, by lowering the character limit to 1960 it'll fix this.

![Too Many Letters](https://user-images.githubusercontent.com/24445435/36522126-bb5902b6-1768-11e8-8f3e-c4ab42ad50ed.png)